### PR TITLE
Finish up first part of the assignment

### DIFF
--- a/files/hosts
+++ b/files/hosts
@@ -1,0 +1,6 @@
+127.0.0.1   localhost
+::1         localhost ip6-localhost ip6-loopback
+
+192.168.56.10   master
+192.168.56.11   worker1
+192.168.56.12   worker2

--- a/general.yaml
+++ b/general.yaml
@@ -55,3 +55,20 @@
   - name: Update apt cache
     ansible.builtin.apt:
       update_cache: yes
+  
+  - name: Install containerd and runc from Ubuntu
+    ansible.builtin.apt:
+      name:
+        - containerd
+        - runc
+      state: present
+      update_cache: no
+
+  - name: Install kubeadm, kubelet and kubectl
+    ansible.builtin.apt:
+      name:
+        - kubeadm
+        - kubelet
+        - kubectl
+      state: present
+      update_cache: no

--- a/general.yaml
+++ b/general.yaml
@@ -23,3 +23,35 @@
       owner: root
       group: root
       mode: '0644'
+
+  - name: Ensure apt-transport-https is present
+    ansible.builtin.apt:
+      name: apt-transport-https
+      state: present
+      update_cache: yes
+
+  - name: Create directory for apt keyrings
+    ansible.builtin.file:
+      path: /etc/apt/keyrings
+      state: directory
+      owner: root
+      group: root
+      mode: '0755'
+
+  - name: Add Kubernetes GPG keyring
+    ansible.builtin.apt_key:
+      url: https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key
+      keyring: /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+      state: present
+
+  - name: Add the community Kubernetes apt repository
+    ansible.builtin.apt_repository:
+      repo: >-
+        deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg]
+        https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /
+      filename: kubernetes
+      state: present
+
+  - name: Update apt cache
+    ansible.builtin.apt:
+      update_cache: yes

--- a/general.yaml
+++ b/general.yaml
@@ -72,3 +72,46 @@
         - kubectl
       state: present
       update_cache: no
+
+  - name: Ensure /etc/containerd directory exists
+    ansible.builtin.file:
+      path: /etc/containerd
+      state: directory
+      owner: root
+      group: root
+      mode: '0755'
+
+  - name: Generate default containerd config if missing
+    ansible.builtin.shell: >
+      containerd config default > /etc/containerd/config.toml
+    args:
+      creates: /etc/containerd/config.toml
+
+  - name: Disable AppArmor in containerd config
+    ansible.builtin.lineinfile:
+      path: /etc/containerd/config.toml
+      regexp: '^\s*disable_apparmor\s*='
+      line: '            disable_apparmor = true'
+
+  - name: Update sandbox image version in containerd config
+    ansible.builtin.lineinfile:
+      path: /etc/containerd/config.toml
+      regexp: '^\s*sandbox_image\s*='
+      line: '            sandbox_image = "registry.k8s.io/pause:3.10"'
+
+  - name: Enable systemd cgroup in runc options
+    ansible.builtin.lineinfile:
+      path: /etc/containerd/config.toml
+      regexp: '^\s*SystemdCgroup\s*='
+      line: '        SystemdCgroup = true'
+
+  - name: Restart containerd to load new config
+    ansible.builtin.service:
+      name: containerd
+      state: restarted
+
+  - name: Enable and start kubelet service
+    ansible.builtin.systemd:
+      name: kubelet
+      enabled: yes
+      state: started

--- a/general.yaml
+++ b/general.yaml
@@ -16,3 +16,10 @@
       path: /etc/fstab
       state: absent
       regexp: 'swap'
+  - name: Distribute static /etc/hosts with cluster mappings
+    ansible.builtin.copy:
+      src: files/hosts
+      dest: /etc/hosts
+      owner: root
+      group: root
+      mode: '0644'

--- a/node.yaml
+++ b/node.yaml
@@ -9,4 +9,31 @@
       community.general.modprobe:
         name: br_netfilter
         state: present
+    - name: Create Kubernetes module load configuration
+      ansible.builtin.copy:
+        content: |
+          overlay
+          br_netfilter
+        dest: /etc/modules-load.d/k8s.conf
     
+    - name: Load overlay module
+      ansible.builtin.shell: modprobe overlay
+    
+    - name: Load br_netfilter module
+      ansible.builtin.shell: modprobe br_netfilter
+    
+    - name: Verify overlay is loaded
+      ansible.builtin.shell: lsmod | grep overlay
+      register: overlay_check
+
+    - name: Verify br_netfilter is loaded
+      ansible.builtin.shell: lsmod | grep br_netfilter
+      register: br_netfilter_check
+    
+    - name: Display overlay load status
+      debug:
+        msg: "{{ overlay_check.stdout }}"
+    
+    - name: Display br_netfilter load status
+      debug:
+        msg: "{{ br_netfilter_check.stdout }}"

--- a/node.yaml
+++ b/node.yaml
@@ -37,3 +37,17 @@
     - name: Display br_netfilter load status
       debug:
         msg: "{{ br_netfilter_check.stdout }}"
+
+    - name: Ensure required sysctl params for Kubernetes networking
+      ansible.builtin.sysctl:
+        name: "{{ item.name }}"
+        value: "{{ item.value }}"
+        sysctl_file: /etc/sysctl.d/k8s.conf
+        state: present
+        reload: yes
+      loop:
+        - { name: net.ipv4.ip_forward,                 value: "1" }
+        - { name: net.bridge.bridge-nf-call-iptables,  value: "1" }
+        - { name: net.bridge.bridge-nf-call-ip6tables, value: "1" }
+      loop_control:
+        label: "{{ item.name }}"


### PR DESCRIPTION
Implemented the following steps:

1. Enable Network Bridging (br_netfilter):
   - Load the br_netfilter module for Linux to handle bridged traffic.
   - Automatically load it on boot by adding it to /etc/modules-load.d/k8s.conf.
   - Use modprobe to activate it immediately.

2. Enable IPv4 Forwarding and Bridged Connections:
   - Activate IPv4 packet forwarding with sysctl.
   - Enable bridge-related IP forwarding (net.bridge.bridge-nf-call-iptables and net.bridge.bridge-nf-call-ip6tables) if br_netfilter is active.

3. Manage /etc/hosts for Node Communication:
   - Ensure each node can reach others by hostname.
   - Populate /etc/hosts manually or with Ansible's copy or blockinfile modules.

4. Add Kubernetes Repository:
   - Install the official Kubernetes GPG key and add the Kubernetes repository for updated packages.
   - Refresh the apt package index after adding the repository.

5. Install Kubernetes Tools:
   - Use apt to install:
     - containerd (v1.7.24)
     - runc (v1.1.12)
     - kubeadm, kubelet, and kubectl (all v1.32.4).

6. Configure Containerd:
   - Dump the default config to /etc/containerd/config.toml.
   - Update the configuration:
     - Disable AppArmor (disable_apparmor = true).
     - Set the sandbox image to registry.k8s.io/pause:3.10.
     - Enable SystemdCgroup.
   - Restart containerd to apply changes.

7. Start Kubelet Service:
   - Launch kubelet and enable it to start automatically on boot.
