### PR TITLE
Add istio traffic management

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,53 @@ Key values you might want to customize:
     ```
 2.  **Open in Browser:**
     Open your web browser and navigate to the configured host (e.g., `http://prometheus.local`).
+
+# How to run our application for Assignment 5
+# Usage Instructions
+
+This guide explains how to deploy the v1 and v2 (canary) versions of the application using Istio for traffic management.
+
+## Prerequisites
+
+* Kubernetes cluster running (You have followed all previous steps).
+* Istio installed.
+* Deployment namespace (e.g., `default`) enabled for Istio sidecar injection:
+    ```bash
+    kubectl label namespace default istio-injection=enabled
+    ```
+
+## Step 1: Deploy App
+
+This deploys the main version of `app` alongside a canary release and `model-service`, with Istio configurations (Gateway, DestinationRules, VirtualServices for 90/10 split and consistent routing).
+
+1.  Apply `app.yml`:
+    ```bash
+    kubectl apply -f app.yml
+    ```
+
+2.  Apply `app-canary.yml`:
+    ```bash
+    kubectl apply -f app-canary.yml
+    ```
+3.  Wait for pods to be ready:
+    ```bash
+    kubectl get pods -n default -w
+    ```
+    The 90/10 traffic split defined in `app.yml` (and reaffirmed in `app-canary.yml`) will now route 10% of traffic to `app-v2`.
+
+## Step 2: Access the Application
+
+1.  Get the Istio Ingress Gateway address:
+    ```bash
+    kubectl get svc istio-ingressgateway -n istio-system
+    ```
+2.  Copy the `EXTERNAL-IP` and paste it in your browser.
+
+## Step 3: Observe Canary Release
+
+Refresh your browser multiple times. You should see traffic split between `app-v1` (90%) and `app-v2` (10%), with `model-service` versions consistent with the `app` version.
+
+
 ## Related Repositories 
 
 | Repo                                                              | Purpose                               |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,8 @@ Vagrant.configure("2") do |config|
 
     # Set memory to 4GB and CPU to 1
     ctrl_node.vm.provider "virtualbox" do |v|
-      v.memory = 4096
-      v.cpus = 2
+      v.memory = 16384
+      v.cpus = 4
     end
 
     # Open the control playbook.

--- a/istio/app-canary.yml
+++ b/istio/app-canary.yml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-v2
+  labels: { app: app, version: v2 }
+  annotations:
+    prometheus.io/scrape: "true" # this is the magic instruction to enable metric pick-up
+    prometheus.io/path: "/metrics" # optional, needed for non-default paths
+    prometheus.io/port: "3001"
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/remla25-team4/app:0.4.3
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 3001
+    env:
+      - name: MODEL_SERVICE_URL
+        value: "http://model-service:8080"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: model-service-v2
+  labels: { app: model-service, version: v2 }
+  annotations:
+    prometheus.io/scrape: "true" # this is the magic instruction to enable metric pick-up
+    prometheus.io/path: "/metrics" # optional, needed for non-default paths
+    prometheus.io/port: "8080"
+spec:
+  containers:
+  - name: model-service-container
+    image: ghcr.io/remla25-team4/model-service:1.0.0
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 8080
+    env:
+    - name: MODEL_URL
+      value: "https://github.com/remla25-team4/model-training/raw/main/models/naive_bayes.joblib"

--- a/istio/app.yml
+++ b/istio/app.yml
@@ -3,24 +3,40 @@ kind: Pod
 metadata:
   name: app-v1
   labels: { app: app, version: v1 }
+  annotations:
+    prometheus.io/scrape: "true" # this is the magic instruction to enable metric pick-up
+    prometheus.io/path: "/metrics" # optional, needed for non-default paths
+    prometheus.io/port: "3001"
 spec:
   containers:
   - name: app
-    image: ghcr.io/remla25-team4/app:latest
-    ports: [ containerPort: 3001 ]
+    image: ghcr.io/remla25-team4/app:0.4.2
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 3001
+    env:
+      - name: MODEL_SERVICE_URL
+        value: "http://model-service:8080"
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  name: svc-v1
-  labels: { app: svc, version: v1 }
+  name: model-service-v1
+  labels: { app: model-service, version: v1 }
+  annotations:
+    prometheus.io/scrape: "true" # this is the magic instruction to enable metric pick-up
+    prometheus.io/path: "/metrics" # optional, needed for non-default paths
+    prometheus.io/port: "8080"
 spec:
   containers:
-  - name: svc
-    image: ghcr.io/remla25-team4/model-service:latest
-    ports: [ containerPort: 8080 ]
+  - name: model-service-container
+    image: ghcr.io/remla25-team4/model-service:1.0.0
+    imagePullPolicy: Always
+    ports:
+    - containerPort: 8080
     env:
-    - { MODEL_URL: "https://github.com/remla25-team4/model-training/raw/main/models/naive_bayes.joblib" }
+    - name: MODEL_URL
+      value: "https://github.com/remla25-team4/model-training/raw/main/models/naive_bayes.joblib"
 ---
 apiVersion: v1
 kind: Service
@@ -32,17 +48,82 @@ spec:
 ---
 apiVersion: v1
 kind: Service
-metadata: { name: svc }
+metadata: { name: model-service }
 spec:
-  selector: { app: svc }
+  selector: { app: model-service }
   ports:
-  - { name: http, port: 1234, targetPort: 8080 }
+  - { name: http, port: 8080, targetPort: 8080 }
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
-metadata: { name: my-gateway }
+metadata:
+  name: my-gateway
 spec:
-  selector: { istio: ingressgateway }
+  selector:
+    istio: ingressgateway
   servers:
-  - port: { number: 80, name: http, protocol: HTTP }
-  hosts: [ "*" ]
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts: [ "*" ]
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-service-dr
+spec:
+  host: model-service
+  subsets:
+    - name: v1
+      labels: { version: v1 }
+    - name: v2
+      labels: { version: v2 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service-vs
+spec:
+  hosts: [ model-service ]
+  http:
+  - match:
+    - sourceLabels: { version: v2 }
+    route:
+    - destination: { host: model-service, subset: v2 }
+  - route: # default route
+    - destination: { host: model-service, subset: v1 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata: { name: app-dr }
+spec:
+  host: app
+  subsets:
+  - name: v1
+    labels: { version: v1 }
+  - name: v2
+    labels: { version: v2 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: my-entry-service
+spec:
+  gateways:
+    - my-gateway
+  hosts:
+    - "*"
+  http:
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: app
+            subset: v1
+          weight: 90
+        - destination:
+            host: app
+            subset: v2
+          weight: 10

--- a/istio/app.yml
+++ b/istio/app.yml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-v1
+  labels: { app: app, version: v1 }
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/remla25-team4/app:latest
+    ports: [ containerPort: 3001 ]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: svc-v1
+  labels: { app: svc, version: v1 }
+spec:
+  containers:
+  - name: svc
+    image: ghcr.io/remla25-team4/model-service:latest
+    ports: [ containerPort: 8080 ]
+    env:
+    - { MODEL_URL: "https://github.com/remla25-team4/model-training/raw/main/models/naive_bayes.joblib" }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: app }
+spec:
+  selector: { app: app }
+  ports:
+  - { name: http, port: 1234, targetPort: 3001 }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: svc }
+spec:
+  selector: { app: svc }
+  ports:
+  - { name: http, port: 1234, targetPort: 8080 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata: { name: my-gateway }
+spec:
+  selector: { istio: ingressgateway }
+  servers:
+  - port: { number: 80, name: http, protocol: HTTP }
+  hosts: [ "*" ]


### PR DESCRIPTION
Implemented Istio Canary Release for App & Model Service

Adds/Updates Kubernetes and Istio manifests (app.yml, app-canary.yml) to deploy v1 and v2 of the app. Configures a 90/10 canary traffic split and ensures consistent version routing.