### PR TITLE
Should now reach excellent for the vagrantfile part

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,15 +22,19 @@ Vagrant.configure("2") do |config|
     trigger.ruby do
       
       File.open("inventory.cfg", 'w') do |f|
-        f.puts "[ctrl]"
-        f.puts "ansible-host=#{network_base}100"
+        f.puts "[controller]"
+        f.puts "ctrl ansible_host=#{network_base}100"
         f.puts ""
         
+        f.puts "[workers]"
         (1..num_workers).each do |i|
-          f.puts "[node-{i}]"
-          f.puts "ansible_host=#{network_base}10#{i} ansible_user=vagrant"
-          f.puts ""
+          f.puts "node-#{i} ansible_host=#{network_base}10#{i} ansible_user=vagrant"
         end
+
+        f.puts ""
+        f.puts "[all:children]"
+        f.puts "controller"
+        f.puts "workers"
       end
       puts "Inventory file creation succeeded"
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,4 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = "bento/ubuntu-24.04"
@@ -18,20 +7,53 @@ Vagrant.configure("2") do |config|
   # Number of worker nodes
   num_workers = 2
 
+  # Variables for ctrl node
+  ctrl_cpus = 2
+  ctrl_memory = 4096
+
+  # Variables for worker nodes
+  worker_memory = 6144
+  worker_cpus = 2
+
+  # Network base
+  network_base = "192.168.56."
+
+  config.trigger.after :up do |trigger|
+    trigger.ruby do
+      
+      File.open("inventory.cfg", 'w') do |f|
+        f.puts "[ctrl]"
+        f.puts "ansible-host=#{network_base}100"
+        f.puts ""
+        
+        (1..num_workers).each do |i|
+          f.puts "[node-{i}]"
+          f.puts "ansible_host=#{network_base}10#{i} ansible_user=vagrant"
+          f.puts ""
+        end
+      end
+      puts "Inventory file creation succeeded"
+    end
+  end
+
+
   # Open the general setup playbook.
   config.vm.provision :ansible do |a|
     a.playbook = "general.yaml"
+    a.extra_vars = {
+        num_workers: num_workers
+      }
   end
 
   # Define control node
   config.vm.define "ctrl" do |ctrl_node|
     ctrl_node.vm.hostname = "ctrl"
-    ctrl_node.vm.network "private_network", ip: "192.168.56.100"
+    ctrl_node.vm.network "private_network", ip: "#{network_base}100"
 
     # Set memory to 4GB and CPU to 1
     ctrl_node.vm.provider "virtualbox" do |v|
-      v.memory = 8192
-      v.cpus = 4
+      v.memory = ctrl_memory
+      v.cpus = ctrl_cpus
     end
 
     # Open the control playbook.
@@ -45,18 +67,21 @@ Vagrant.configure("2") do |config|
     # Define first worker
     config.vm.define "node-#{i}" do |node|
       node.vm.hostname = "node-#{i}"
-      node.vm.network "private_network", ip: "192.168.56.10#{i}"
+      node.vm.network "private_network", ip: "#{network_base}10#{i}"
 
       # Set memory & CPU
       node.vm.provider "virtualbox" do |v|
-        v.memory = 6144
-        v.cpus = 2
+        v.memory = worker_memory
+        v.cpus = worker_cpus
       end
 
       # Open the node playbook.
       node.vm.provision :ansible do |a|
         a.playbook = "node.yaml"
       end
+
     end
+
   end
+
 end


### PR DESCRIPTION
Rubric points improved:
- [x] Used CPU cores, memory size, and number of provisioned worker nodes are controlled via variables.
- [x] Extra arguments are passed from Vagrant to Ansible (e.g., number of workers)
- [x] Vagrant generates a valid inventory.cfg for Ansible that contains all (and only) the active nodes