### PR TITLE
Seperate sticky routing from weighted routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ kubeconfig
 
 .idea
 get_helm.sh
+/inventory.cfg

--- a/README.md
+++ b/README.md
@@ -281,9 +281,33 @@ This deploys the main version of `app` alongside a canary release and `model-ser
     ```
 2.  Copy the `EXTERNAL-IP` and paste it in your browser.
 
-### Step 3: Observe Canary Release
+### Step 3: Choose Routing Strategy
 
-Refresh your browser multiple times. You should see traffic split between `app-v1` (90%) and `app-v2` (10%), with `model-service` versions consistent with the `app` version.
+For this assignment, we have implemented both the option to route traffic with weights (v1: 90% / v2: 10%) and sticky sessions (odd userids always get v1 and even userids get v2)
+
+To enable weighted routing:
+
+```bash
+kubectl apply -f weighted-routing.yml
+```
+
+To enable sticky routing:
+
+```bash
+kubectl apply -f sticky-routing.yml
+```
+
+Note: To test the correctness of the routing behavior, you can use the following command:
+
+```bash
+curl -H "userid: 1" 192.168.56.91/api/versions
+```
+
+For weighted routing, you should see that an older version of app is displayed most of the time.
+
+For sticky routing, if the userid value is odd, the app version will always be the older one (v1) and will not change if userid stays the same
+If the userid is changed to an even numberm the app version should now be the newer one (v2).
+
 
 ### step 4: Rate-limiting
 

--- a/istio/app-canary.yml
+++ b/istio/app-canary.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: ghcr.io/remla25-team4/app:2.0.0
+    image: ghcr.io/remla25-team4/app:latest
     imagePullPolicy: Always
     ports:
     - containerPort: 3001

--- a/istio/app.yml
+++ b/istio/app.yml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: ghcr.io/remla25-team4/app:0.4.2
+    image: ghcr.io/remla25-team4/app:0.4.3
     imagePullPolicy: Always
     ports:
     - containerPort: 3001
@@ -31,7 +31,7 @@ metadata:
 spec:
   containers:
   - name: model-service-container
-    image: ghcr.io/remla25-team4/model-service:1.0.0
+    image: ghcr.io/remla25-team4/model-service:1.0.1
     imagePullPolicy: Always
     ports:
     - containerPort: 8080
@@ -56,48 +56,6 @@ spec:
   ports:
   - { name: http, port: 8080, targetPort: 8080 }
 ---
-
-apiVersion: networking.istio.io/v1beta1
-kind: DestinationRule
-metadata:
-  name: model-service-dr
-spec:
-  host: model-service
-  subsets:
-    - name: v1
-      labels: { version: v1 }
-    - name: v2
-      labels: { version: v2 }
----
-apiVersion: networking.istio.io/v1beta1
-kind: DestinationRule
-metadata: { name: app-dr }
-spec:
-  host: app
-  subsets:
-  - name: v1
-    labels: { version: v1 }
-  - name: v2
-    labels: { version: v2 }
-  trafficPolicy:
-    loadBalancer:
-      consistentHash:
-        httpHeaderName: test-user
----
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: model-service-vs
-spec:
-  hosts: [ model-service ]
-  http:
-  - match:
-    - sourceLabels: { version: v2 }
-    route:
-    - destination: { host: model-service, subset: v2 }
-  - route: # default route
-    - destination: { host: model-service, subset: v1 }
----
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -112,39 +70,3 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
----
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: my-entry-service
-spec:
-  gateways:
-    - my-gateway
-  hosts:
-    - "*"
-  http:
-    - match:
-        - headers:
-            test-user:
-              regex: ".+" # Matches if the x-user header is present
-          uri:
-            prefix: /
-      route:
-        - destination:
-            host: app
-            subset: v2
-          weight: 100
-
-    # Default route for other users (90/10 split)
-    - match:
-        - uri:
-            prefix: /
-      route:
-        - destination:
-            host: app
-            subset: v1
-          weight: 90
-        - destination:
-            host: app
-            subset: v2
-          weight: 10

--- a/istio/sticky-routing.yml
+++ b/istio/sticky-routing.yml
@@ -1,0 +1,55 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata: { name: app-dr }
+spec:
+  host: app
+  subsets:
+  - name: v1
+    labels: { version: v1 }
+  - name: v2
+    labels: { version: v2 }
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: userid
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app
+spec:
+  gateways:
+    - my-gateway
+  hosts:
+    - "*"
+  http:
+    - match:
+      - headers:
+          userid:
+            regex: ".*[02468]$" # even user ids get v2 always
+      route:
+      - destination:
+          host: app
+          subset: v2
+    - route:
+      - destination:
+          host: app
+          subset: v1  # odd user ids get v1
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-service-dr
+spec:
+  host: model-service
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: "userid"

--- a/istio/weighted-routing.yml
+++ b/istio/weighted-routing.yml
@@ -1,0 +1,56 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata: { name: app-dr }
+spec:
+  host: app
+  subsets:
+  - name: v1
+    labels: { version: v1 }
+  - name: v2
+    labels: { version: v2 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app
+spec:
+  gateways:
+    - my-gateway
+  hosts:
+    - "*"
+  http:
+  - route:
+    - destination:
+        host: app
+        subset: v1
+      weight: 90
+    - destination:
+        host: app
+        subset: v2
+      weight: 10
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-service-dr
+spec:
+  host: model-service
+  subsets:
+    - name: v1
+      labels: { version: v1 }
+    - name: v2
+      labels: { version: v2 }
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service-vs
+spec:
+  hosts: [ model-service ]
+  http:
+  - match:
+    - sourceLabels: { version: v2 }
+    route:
+    - destination: { host: model-service, subset: v2 }
+  - route:
+    - destination: { host: model-service, subset: v1 }


### PR DESCRIPTION
Seperated the original destination routing virtual service into a weighted and a sticky version.

The weighted one routes traffic with a 90/10 split

The sticky one checks for a header 'userid'. Even userids are assigned to the canary release and is persistent
Odd userids are assigned to the older version of the app.